### PR TITLE
update lambda runtime to latest nodejs version

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -32,7 +32,7 @@ Resources:
         - ResourceName: CognitoTriggered
       CodeUri: src/CognitoTriggered
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       MemorySize: 3008
       Timeout: 30
       Tracing: Active
@@ -80,7 +80,7 @@ Resources:
         - ResourceName: Signup
       CodeUri: src/Signup
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       MemorySize: 3008
       Timeout: 30
       Tracing: Active
@@ -123,7 +123,7 @@ Resources:
         - ResourceName: AuthenticatedApi
       CodeUri: src/AuthenticatedApi
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       MemorySize: 3008
       Timeout: 30
       Tracing: Active


### PR DESCRIPTION
Shift lambda function runtime from nodejs 8 to 12.

I haven't yet tested that these functions run with 12, but can tomorrow. 